### PR TITLE
DM-38329: Perform Zero Calibration when setting mode and range

### DIFF
--- a/python/lsst/ts/electrometer/commander.py
+++ b/python/lsst/ts/electrometer/commander.py
@@ -78,7 +78,7 @@ class Commander:
         async with self.lock:
             try:
                 connect_task = asyncio.open_connection(
-                    host=self.host, port=int(self.port)
+                    host=self.host, port=int(self.port), limit=1024 * 1024
                 )
                 self.reader, self.writer = await asyncio.wait_for(
                     connect_task, timeout=self.long_timeout

--- a/python/lsst/ts/electrometer/commands_factory.py
+++ b/python/lsst/ts/electrometer/commands_factory.py
@@ -321,6 +321,19 @@ class ElectrometerCommandFactory:
         command = ":trac:data?;"
         return command
 
+    def output_trigger_line(self, output_trigger_input):
+        """Sets output trigger line
+
+        Returns
+        -------
+        command : `str`
+            The generated command string.
+        """
+        command = (
+            f"TRIG:TCON:ASYN:OLIN {output_trigger_input:d};TRIG:TCON:ASYN:OUTP SENS;"
+        )
+        return command
+
     def reset_device(self):
         """Return reset device.
 
@@ -580,13 +593,15 @@ class ElectrometerCommandFactory:
         """
         command = (
             f"{self.clear_buffer()} "
-            f" {self.format_trac(channel=False, timestamp=True, temperature=False)} "
+            f"{self.format_trac()} "
             f"{self.set_buffer_size(50000)}"
         )
         return command
 
     def perform_zero_calibration(self, mode, auto, range_value):
         """Return combo of commands for perform zero calibration command.
+        Required when setting mode to Volts/Amps to cancel any internal
+        offsets. See page 4-10 in User's manual for sequence
 
         Parameters
         ----------
@@ -603,10 +618,10 @@ class ElectrometerCommandFactory:
             The generated command string
         """
         command = (
-            f"{self.enable_zero_check(True)} "
-            f"{self.set_mode(mode)} "
-            f" {self.set_range(auto=auto, range_value=range_value, mode=mode)} "
-            f" {self.enable_zero_correction(enable=True)} "
+            f"{self.set_mode(mode)}"
+            f"{self.enable_zero_check(True)}"
+            f"{self.set_range(auto=auto, range_value=range_value, mode=mode)}"
+            f"{self.enable_zero_correction(enable=True)}"
             f"{self.enable_zero_check(False)}"
         )
         return command
@@ -623,11 +638,13 @@ class ElectrometerCommandFactory:
         return command
 
     def toggle_voltage_source(self, enable):
-        command = ":vsou:oper ON;" if enable else ":vsou:oper OFF;"
+        command = (
+            ":sens:res:man:vso:oper ON;" if enable else ":sens:res:man:vso:oper OFF;"
+        )
         return command
 
     def get_voltage_source_status(self):
-        command = ":vsou:oper?;"
+        command = ":sens:res:man:vso:oper?;"
         return command
 
     def get_voltage_level(self):

--- a/python/lsst/ts/electrometer/csc.py
+++ b/python/lsst/ts/electrometer/csc.py
@@ -311,8 +311,8 @@ class ElectrometerCsc(salobj.ConfigurableCsc):
             substates=[DetailedState.NOTREADINGSTATE], action="startScan"
         )
         try:
-            await self.controller.start_scan()
             await self.report_detailed_state(DetailedState.MANUALREADINGSTATE)
+            await self.controller.start_scan()
             self.log.debug("startScan Completed")
         except Exception as e:
             msg = "startScanDt failed."
@@ -367,9 +367,11 @@ class ElectrometerCsc(salobj.ConfigurableCsc):
             await self.controller.stop_scan()
             await self.report_detailed_state(DetailedState.NOTREADINGSTATE)
             self.log.info("stopScan Completed")
-        except Exception:
+        except Exception as e:
+            msg = "stopScan failed."
             self.log.exception("stopScan failed.")
             await self.report_detailed_state(DetailedState.NOTREADINGSTATE)
+            await self.fault(code=enums.Error.FILE_ERROR, report=f"{msg}: {repr(e)}")
 
     async def do_setVoltageSource(self, data):
         self.assert_enabled()

--- a/python/lsst/ts/electrometer/enums.py
+++ b/python/lsst/ts/electrometer/enums.py
@@ -35,7 +35,7 @@ class UnitMode(str, enum.Enum):
     """Voltage"""
 
     RES = "RES"
-    """Resolution"""
+    """Resistance"""
 
 
 class Filter(enum.IntEnum):

--- a/python/lsst/ts/electrometer/mock_server.py
+++ b/python/lsst/ts/electrometer/mock_server.py
@@ -147,9 +147,9 @@ class MockKeithley:
             ): self.do_change_nplc,
             re.compile(r"^:disp:enab (?P<parameter>ON|OFF);$"): self.do_change_nplc,
             re.compile(
-                r"^:vsou:oper (?P<parameter>ON|OFF);$"
+                r"^:sens:res:man:vso:oper (?P<parameter>ON|OFF);$"
             ): self.do_toggle_voltage_source,
-            re.compile(r"^:vsou:oper\?;$"): self.get_voltage_source_status,
+            re.compile(r"^:sens:res:man:vso:oper\?;$"): self.get_voltage_source_status,
             re.compile(r"^:sour:volt:lim:ampl 2;$"): self.set_voltage_limit,
             re.compile(r"^:sour:volt:lim:stat\?;$"): self.get_voltage_limit,
             re.compile(r"^:sour:volt:rang 1;$"): self.set_voltage_range,


### PR DESCRIPTION
The perform_zero_calibration, which already existed, is now run anytime a mode or range is set. Also some changes to get_mode, which wasn't working correctly.