### PR TITLE
tickets/OSW 559

### DIFF
--- a/doc/news/DM-51723.bugfix.rst
+++ b/doc/news/DM-51723.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the Keysight so that when it sets the timer it also sets the appropriate trigger wait time.

--- a/doc/news/OSW-559.bugfix.rst
+++ b/doc/news/OSW-559.bugfix.rst
@@ -1,0 +1,1 @@
+Added get_integration_time call to set_timer to get updated integration time.

--- a/doc/news/OSW-559.feature.1.rst
+++ b/doc/news/OSW-559.feature.1.rst
@@ -1,0 +1,1 @@
+Improved check_error by getting all potential non zero error codes.

--- a/doc/news/OSW-559.feature.rst
+++ b/doc/news/OSW-559.feature.rst
@@ -1,0 +1,1 @@
+Improved retry loop by reconnecting if disconnected for whatever reason.

--- a/python/lsst/ts/electrometer/commander.py
+++ b/python/lsst/ts/electrometer/commander.py
@@ -136,6 +136,8 @@ class Commander:
                                     reply += byte
                                     break
                             except ConnectionError:
+                                self.log.exception("Connection lost...Reconnecting.")
+                                await self.disconnect()
                                 await self.connect()
                                 continue
                             except Exception:

--- a/python/lsst/ts/electrometer/commander.py
+++ b/python/lsst/ts/electrometer/commander.py
@@ -148,23 +148,6 @@ class Commander:
                 reply = reply.rstrip(self.client.terminator).decode(
                     self.client.encoding
                 )
-                # while not reply.endswith(self.client.terminator):
-                #     for _ in range(10):
-                #         try:
-                #             if not self.connected:
-                #                 await self.connect()
-                #             byte = await self.client.read(1)
-                #             if byte:
-                #                 break
-                #         except ConnectionError:
-                #             self.log.exception("Lost connection...")
-                #         except Exception:
-                #             self.log.exception("")
-                #     if byte:
-                #         reply += byte
-                # reply = reply.rstrip(self.client.terminator).decode(
-                #     self.client.encoding
-                # )
                 return reply
 
     def configure(self, config):

--- a/python/lsst/ts/electrometer/commands_factory.py
+++ b/python/lsst/ts/electrometer/commands_factory.py
@@ -1052,3 +1052,14 @@ class KeysightElectrometerCommandFactory(ElectrometerCommandFactory):
         """
         command = ":trig:coun INF;"
         return command
+
+    def set_timer(self, mode, value):
+        """Return set time command string.
+
+        Returns
+        -------
+        command : `str`
+            The generated command string.
+        """
+        command = f":sens:{enums.UnitMode(mode).lower()}:nplc {value};:trig:acq:tim {value/50:f};"
+        return command

--- a/python/lsst/ts/electrometer/commands_factory.py
+++ b/python/lsst/ts/electrometer/commands_factory.py
@@ -681,6 +681,9 @@ class ElectrometerCommandFactory:
         command = f":sens:{enums.UnitMode(mode).value}:dig {digit};"
         return command
 
+    def clear(self):
+        return "*CLS;"
+
 
 class KeithleyElectrometerCommandFactory(ElectrometerCommandFactory):
     """Class that formats commands to control the electrometer via RS-232."""

--- a/python/lsst/ts/electrometer/controller.py
+++ b/python/lsst/ts/electrometer/controller.py
@@ -206,6 +206,7 @@ class ElectrometerController(abc.ABC):
         self.location = config.location
         self.electrometer_type = config.electrometer_type
         self.model_id = config.electrometer_model
+        self.image_service_client = None
 
     @classmethod
     @abc.abstractmethod
@@ -395,6 +396,7 @@ class ElectrometerController(abc.ABC):
             This is passed into this method as it is called
             in the CSC, but it is used in write_fits_file
         """
+        assert self.image_service_client is not None
         self.group_id = group_id
         await self.prepare_scan()
         await self.perform_zero_calibration()
@@ -432,6 +434,7 @@ class ElectrometerController(abc.ABC):
             This is passed into this method as it is called
             in the CSC, but it is used in write_fits_file
         """
+        assert self.image_service_client is not None
         self.group_id = group_id
         await self.prepare_scan()
         await self.perform_zero_calibration()


### PR DESCRIPTION
Along with retrying to send commands and receive responses from the electrometer, we should also reconnect to the moxa if we lose connection to improve reliability. We also can receive more than one error code from a given command and so now the code will loop until it receives a zero error code indicating no issue found. This PR also fixes an issue with the keysight's integration time and NPLC being set incorrectly.
